### PR TITLE
Rearrange the code of cordova-plugin-battery-status so that the intro…

### DIFF
--- a/scripts/patches/after_build_android/battery-status.patch
+++ b/scripts/patches/after_build_android/battery-status.patch
@@ -1,7 +1,7 @@
 diff -ruNb origin_plugins/cordova-plugin-battery-status/types/index.d.ts plugins/cordova-plugin-battery-status/types/index.d.ts
 --- origin_plugins/cordova-plugin-battery-status/types/index.d.ts	null
 +++ plugins/cordova-plugin-battery-status/types/index.d.ts	null
-@@ -4,12 +4,22 @@
+@@ -4,12 +4,33 @@
  //                 Tim Brust <https://github.com/timbru31>
  // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
  
@@ -17,6 +17,17 @@ diff -ruNb origin_plugins/cordova-plugin-battery-status/types/index.d.ts plugins
 +* <br>
 +* window.addEventListener("batterystatus", onBatteryStatus, false);
 +*/
++
++declare namespace CordovaBatteryStatusPlugin {
++    type batteryEvent = 'batterystatus' | 'batterycritical' | 'batterylow';
++
++    interface BatteryStatusEvent extends Event {
++        /* The percentage of battery charge (0-100). */
++        level: number;
++        /* A boolean that indicates whether the device is plugged in. */
++        isPlugged: boolean;
++    }
++}
  
  interface Window {
 -    onbatterystatus: (type: BatteryStatusEvent) => void;
@@ -28,7 +39,7 @@ diff -ruNb origin_plugins/cordova-plugin-battery-status/types/index.d.ts plugins
      /**
       * Adds a listener for an event from the BatteryStatus plugin.
       * @param type       - The event to listen for.
-@@ -22,7 +32,7 @@
+@@ -22,7 +43,7 @@
       * @param listener   - The function that executes when the event fires. The function is passed an BatteryStatusEvent object as a parameter.
       * @param useCapture - A Boolean indicating whether events of this type will be dispatched to the registered listener before being dispatched to any EventTarget beneath it in the DOM tree.
       */
@@ -37,24 +48,19 @@ diff -ruNb origin_plugins/cordova-plugin-battery-status/types/index.d.ts plugins
      /**
       * Removes a listener for an event from the BatteryStatus plugin.
       * @param Atype      - The event to stop listening for.
-@@ -35,12 +45,16 @@
+@@ -35,12 +56,5 @@
       * @param callback   - The function that executes when the event fires. The function is passed an BatteryStatusEvent object as a parameter.
       * @param useCapture - A Boolean indicating whether events of this type will be dispatched to the registered listener before being dispatched to any EventTarget beneath it in the DOM tree.
       */
 -    removeEventListener(type: batteryEvent, listener: (ev: BatteryStatusEvent) => any, useCapture?: boolean): void;
-+    removeEventListener(type: CordovaBatteryStatusPlugin.batteryEvent, listener: (ev: CordovaBatteryStatusPlugin.BatteryStatusEvent) => any, useCapture?: boolean): void;
- }
- 
+-}
+-
 -interface BatteryStatusEvent extends Event {
-+declare namespace CordovaBatteryStatusPlugin {
-+    type batteryEvent = 'batterystatus' | 'batterycritical' | 'batterylow';
-+
-+    interface BatteryStatusEvent extends Event {
- 	/* The percentage of battery charge (0-100). */
-     level: number;
- 	/* A boolean that indicates whether the device is plugged in. */
-     isPlugged: boolean;
-+    }
+-	/* The percentage of battery charge (0-100). */
+-    level: number;
+-	/* A boolean that indicates whether the device is plugged in. */
+-    isPlugged: boolean;
++    removeEventListener(type: CordovaBatteryStatusPlugin.batteryEvent, listener: (ev: CordovaBatteryStatusPlugin.BatteryStatusEvent) => any, useCapture?: boolean): void;
  }
 diff -ruNb origin_plugins/cordova-plugin-battery-status/www/battery.js plugins/cordova-plugin-battery-status/www/battery.js
 --- origin_plugins/cordova-plugin-battery-status/www/battery.js	null
@@ -62,17 +68,17 @@ diff -ruNb origin_plugins/cordova-plugin-battery-status/www/battery.js plugins/c
 @@ -19,16 +19,17 @@
   *
  */
-
+ 
 -/**
 - * This class contains information about the current battery status.
 - * @constructor
 - */
  var cordova = require('cordova');
  var exec = require('cordova/exec');
-
+ 
  var STATUS_CRITICAL = 5;
  var STATUS_LOW = 20;
-
+ 
 +
 +/**
 + * This class contains information about the current battery status.


### PR DESCRIPTION
… text can be shown correctly.